### PR TITLE
fix: reserve udp ports using pick-port

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "execa": "^5.0.0",
         "ffmpeg-for-homebridge": "^0.0.9",
-        "get-port": "^5.1.1",
+        "pick-port": "^1.0.0",
         "rxjs": "^6.6.7",
         "systeminformation": "^5.6.10"
       },
@@ -3440,7 +3440,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -5080,17 +5079,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/get-port": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-stdin": {
@@ -7948,8 +7936,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multicast-dns": {
       "version": "7.2.2",
@@ -8554,6 +8541,14 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
+    },
+    "node_modules/pick-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pick-port/-/pick-port-1.0.0.tgz",
+      "integrity": "sha512-8h9ShAAM5z691zpibEAIyQWiGjjxh5AsP62qI9ptceTDxsSy6bJEXxNpHmdFSwIVNtI2+k3DEhDX+1fYxFHHEA==",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
     },
     "node_modules/picomatch": {
       "version": "2.2.2",
@@ -14868,7 +14863,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -16125,11 +16119,6 @@
           "dev": true
         }
       }
-    },
-    "get-port": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="
     },
     "get-stdin": {
       "version": "4.0.1",
@@ -18287,8 +18276,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multicast-dns": {
       "version": "7.2.2",
@@ -18756,6 +18744,14 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
+    },
+    "pick-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pick-port/-/pick-port-1.0.0.tgz",
+      "integrity": "sha512-8h9ShAAM5z691zpibEAIyQWiGjjxh5AsP62qI9ptceTDxsSy6bJEXxNpHmdFSwIVNtI2+k3DEhDX+1fYxFHHEA==",
+      "requires": {
+        "debug": "^4.1.1"
+      }
     },
     "picomatch": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "execa": "^5.0.0",
     "ffmpeg-for-homebridge": "^0.0.9",
-    "get-port": "^5.1.1",
+    "pick-port": "^1.0.0",
     "rxjs": "^6.6.7",
     "systeminformation": "^5.6.10"
   },

--- a/src/ports.ts
+++ b/src/ports.ts
@@ -1,55 +1,51 @@
-import getPort from 'get-port'
 import { Socket } from 'dgram'
 import { AddressInfo } from 'net'
-
-let reservedPorts: number[] = []
-export function releasePorts(ports: number[]) {
-  reservedPorts = reservedPorts.filter((p) => !ports.includes(p))
-}
+const pickPort = require('pick-port')
 
 // Need to reserve ports in sequence because ffmpeg uses the next port up by default.  If it's taken, ffmpeg will error
 export async function reservePorts({
   count = 1,
+  type = 'udp',
   attemptNumber = 0,
 }: {
   count?: number
+  type?: 'udp' | 'tcp'
   attemptNumber?: number
 } = {}): Promise<number[]> {
   if (attemptNumber > 100) {
     throw new Error('Failed to reserve ports after 100 tries')
   }
 
-  const port = await getPort(),
+  const pickPortOptions = {
+      type,
+      reserveTimeout: 15, // 15 seconds is max setup time for HomeKit streams, so the port should be in use by then
+    },
+    port = await pickPort(pickPortOptions),
     ports = [port],
     tryAgain = () => {
       return reservePorts({
         count,
+        type,
         attemptNumber: attemptNumber + 1,
       })
     }
 
-  if (reservedPorts.includes(port)) {
-    // this avoids race conditions where we can reserve the same port twice
-    return tryAgain()
-  }
-
   for (let i = 1; i < count; i++) {
-    const targetConsecutivePort = port + i,
-      openPort = await getPort({ port: targetConsecutivePort })
+    try {
+      const targetConsecutivePort = port + i,
+        openPort = await pickPort({
+          ...pickPortOptions,
+          minPort: targetConsecutivePort,
+          maxPort: targetConsecutivePort,
+        })
 
-    if (openPort !== targetConsecutivePort) {
+      ports.push(openPort)
+    } catch (_) {
       // can't reserve next port, bail and get another set
       return tryAgain()
     }
-
-    ports.push(openPort)
   }
 
-  if (ports.some((p) => reservedPorts.includes(p))) {
-    return tryAgain()
-  }
-
-  reservedPorts.push(...ports)
   return ports
 }
 
@@ -60,9 +56,6 @@ export function bindToPort(socket: Socket) {
     // 0 means select a random open port
     socket.bind(0, () => {
       const { port } = socket.address() as AddressInfo
-
-      reservedPorts.push(port)
-      socket.once('close', () => releasePorts([port]))
       resolve(port)
     })
   })

--- a/src/return-audio-transcoder.ts
+++ b/src/return-audio-transcoder.ts
@@ -1,7 +1,7 @@
 import { RtpSplitter } from './rtp-splitter'
 import { FfmpegProcess, FfmpegProcessOptions } from './ffmpeg-process'
 import { createCryptoLine } from './srtp'
-import { releasePorts, reservePorts } from './ports'
+import { reservePorts } from './ports'
 import { PrepareStreamRequest } from 'homebridge'
 import { getSsrc } from './rtp'
 
@@ -92,6 +92,5 @@ export class ReturnAudioTranscoder {
   stop() {
     this.ffmpegProcess.stop()
     this.returnRtpSplitter.close()
-    this.reservedPortsPromise.then((ports) => releasePorts(ports))
   }
 }

--- a/src/rtp-splitter.ts
+++ b/src/rtp-splitter.ts
@@ -1,5 +1,5 @@
 import { createSocket, RemoteInfo } from 'dgram'
-import { bindToPort, releasePorts } from './ports'
+import { bindToPort } from './ports'
 import { fromEvent, merge, ReplaySubject } from 'rxjs'
 import { map, share, takeUntil } from 'rxjs/operators'
 import { getPayloadType, isRtpMessagePayloadType } from './rtp'
@@ -79,7 +79,6 @@ export class RtpSplitter {
 
     this.cleanedUp = true
     this.onClose.next()
-    this.portPromise.then((port) => releasePorts([port]))
   }
 
   private closed = false

--- a/test/ports.spec.ts
+++ b/test/ports.spec.ts
@@ -1,7 +1,7 @@
 import { reservePorts } from '../src'
 // import { createSocket } from 'dgram'
 
-// function exportPortToBeOpen(port: number) {
+// function expectPortToBeOpen(port: number) {
 //   return new Promise(async (resolve, reject) => {
 //     const socket = createSocket('udp4')
 //     socket.once('error', reject)
@@ -19,18 +19,18 @@ describe('Port Utils', () => {
     const ports = await reservePorts()
 
     expect(ports).toHaveLength(1)
-    // exportPortToBeOpen(ports[0])
+    // expectPortToBeOpen(ports[0])
   })
 
   it('should be able to reserve multiple port', async () => {
     const ports = await reservePorts({ count: 3 })
 
     expect(ports).toHaveLength(3)
-    // exportPortToBeOpen(ports[0])
+    // expectPortToBeOpen(ports[0])
 
     for (let i = 1; i < ports.length; i++) {
       expect(ports[i]).toEqual(ports[i - 1] + 1)
-      // exportPortToBeOpen(ports[i])
+      // expectPortToBeOpen(ports[i])
     }
   })
 })


### PR DESCRIPTION
BREAKING CHANGE
`reservePorts` previously only reserved ports using tcp.  This was not a correct approach because ffmpeg uses udp to bind to the ports and tcp may be available on ports that are already bound for udp.  `reservePorts` will now use udp by default, but supports tcp if you pass `type: 'tcp'` in the options object.

This is implemented using [pick-port](https://www.npmjs.com/package/pick-port), which keeps an internal reservation list.  The reservations are based on time, which makes sense because we only need to reserve it for a short period for the socket to be bound, and then the port will be "in use" and won't be reservable again until the socket is unbound.  This allowed me to clean up the `releasePort` calls, which is a nice fringe benefit 😄 