### PR TITLE
ffmpeg: Add optional stdout callback

### DIFF
--- a/src/ffmpeg-process.ts
+++ b/src/ffmpeg-process.ts
@@ -18,6 +18,7 @@ export interface FfmpegProcessOptions {
   }
   logLabel?: string
   exitCallback?: (code: number | null, signal: string | null) => unknown
+  stdoutCallback?: (data: any) => unknown
   startedCallback?: () => unknown
 }
 
@@ -38,6 +39,13 @@ export class FfmpegProcess {
       logError = logger?.error || noop,
       logInfo = logger?.info || noop,
       logPrefix = logLabel ? `${logLabel}: ` : ''
+
+    if (options.stdoutCallback) {
+      const { stdoutCallback } = options
+      this.ff.stdout.on('data', (data: any) => {
+        stdoutCallback(data)
+      })
+    }
 
     this.ff.stderr.on('data', (data: any) => {
       if (!this.started) {


### PR DESCRIPTION
## :recycle: Current situation

When using ffmpeg, there are situations where it's nice to simply stream the output the stdout, especially when post-processing is intended to be done within the same program that launched ffmpeg. Right now, if you set the output to `-`, there is no way for the caller to capture that output.

I am using the `ring-client-api`, which depends on this class for transcoding the livestream. If I can get this merged, adding a PR to that repo will be next in order. 
https://github.com/dgreif/ring/blob/4b4e5611bafddc8ca4ad5baba35335c05879b5cc/packages/ring-client-api/streaming/streaming-session.ts#L132-L139

## :bulb: Proposed solution

Add an optional callback for the user to process stdout data.

## :gear: Release Notes

*Provide a summary of the changes or features from a user's point of view. If there are breaking changes, provide migration guides using code examples of the affected features.*

New option `stdoutCallback` added to `FfmpegOptions` struct. If you accept this PR, can you do a release so I can update the dependency in ring-client-api?